### PR TITLE
add terraform

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,7 @@ build/
 _yardoc
 doc/
 .idea/
+
+.terraform
+*.tfstate
+*.tfstate.backup

--- a/terraform/bv-sandbox/baseline.tf
+++ b/terraform/bv-sandbox/baseline.tf
@@ -1,0 +1,22 @@
+provider "aws" {
+  version = "~> 2.40"
+
+  region  = "us-east-1"
+  profile = var.profile
+}
+
+terraform {
+  required_version = ">= 0.12"
+}
+
+variable "managedby" {
+  default = "terraform"
+}
+
+variable "profile" {
+  default = "bv-sandbox"
+}
+
+variable "repo_name" {
+  default = "validityhq/dispatcher"
+}

--- a/terraform/bv-sandbox/baseline.tf
+++ b/terraform/bv-sandbox/baseline.tf
@@ -18,5 +18,5 @@ variable "profile" {
 }
 
 variable "repo_name" {
-  default = "validityhq/dispatcher"
+  default = "validityhq/slate"
 }

--- a/terraform/bv-sandbox/main.tf
+++ b/terraform/bv-sandbox/main.tf
@@ -1,0 +1,4 @@
+module "ecr" {
+  source   = "../modules/ecr"
+  reponame = "bv-slate-docs"
+}

--- a/terraform/bv-sandbox/remote-state.tf
+++ b/terraform/bv-sandbox/remote-state.tf
@@ -1,0 +1,11 @@
+terraform {
+  backend "s3" {
+    bucket         = "bv-terraform-state-dev"
+    dynamodb_table = "terraform-state-lock"
+    encrypt        = true
+    key            = "bv-sandbox/slate/terraform.tfstate"
+    profile        = "bv-sandbox"
+    region         = "us-east-1"
+  }
+}
+

--- a/terraform/modules/ecr/default-lifecycle-policy.json
+++ b/terraform/modules/ecr/default-lifecycle-policy.json
@@ -1,0 +1,28 @@
+{
+    "rules": [
+        {
+            "rulePriority": 1,
+            "description": "Expire all untagged images",
+            "selection": {
+                "tagStatus": "untagged",
+                "countType": "imageCountMoreThan",
+                "countNumber": 1
+            },
+            "action": {
+                "type": "expire"
+            }
+        },
+        {
+            "rulePriority": 2,
+            "description": "Expire the oldest image once we get 800 versions of that image",
+            "selection": {
+                "tagStatus": "any",
+                "countType": "imageCountMoreThan",
+                "countNumber": 800
+            },
+            "action": {
+                "type": "expire"
+            }
+        }
+    ]
+}

--- a/terraform/modules/ecr/ecr-jenkins-policy.json
+++ b/terraform/modules/ecr/ecr-jenkins-policy.json
@@ -1,0 +1,27 @@
+{
+    "Version": "2008-10-17",
+    "Statement": [
+        {
+            "Sid": "ECR Jenkins Policy",
+            "Effect": "Allow",
+            "Principal": {
+                "AWS": [
+                    "arn:aws:iam::596297932419:user/app_jenkins"
+                ]
+            },
+            "Action": [
+                "ecr:GetDownloadUrlForLayer",
+                "ecr:BatchGetImage",
+                "ecr:BatchCheckLayerAvailability",
+                "ecr:PutImage",
+                "ecr:InitiateLayerUpload",
+                "ecr:UploadLayerPart",
+                "ecr:CompleteLayerUpload",
+                "ecr:DescribeRepositories",
+                "ecr:GetRepositoryPolicy",
+                "ecr:ListImages",
+                "ecr:BatchDeleteImage"
+            ]
+        }
+    ]
+}

--- a/terraform/modules/ecr/main.tf
+++ b/terraform/modules/ecr/main.tf
@@ -1,0 +1,16 @@
+resource "aws_ecr_repository" "repository" {
+  name = var.reponame
+  image_scanning_configuration {
+    scan_on_push = true
+  }
+}
+
+resource "aws_ecr_repository_policy" "repo_jenkins_policy" {
+  repository = aws_ecr_repository.repository.name
+  policy     = file("${path.module}/ecr-jenkins-policy.json")
+}
+
+resource "aws_ecr_lifecycle_policy" "repo_lifecycle_policy" {
+  repository = aws_ecr_repository.repository.name
+  policy     = file("${path.module}/default-lifecycle-policy.json")
+}

--- a/terraform/modules/ecr/variables.tf
+++ b/terraform/modules/ecr/variables.tf
@@ -1,0 +1,3 @@
+variable "reponame" {
+  type = string
+}


### PR DESCRIPTION
plan:

```
apackard:bv-sandbox ashleypackard$ terraform plan
Refreshing Terraform state in-memory prior to plan...
The refreshed state will be used to calculate this plan, but will not be
persisted to local or remote state storage.


------------------------------------------------------------------------

An execution plan has been generated and is shown below.
Resource actions are indicated with the following symbols:
  + create

Terraform will perform the following actions:

  # module.ecr.aws_ecr_lifecycle_policy.repo_lifecycle_policy will be created
  + resource "aws_ecr_lifecycle_policy" "repo_lifecycle_policy" {
      + id          = (known after apply)
      + policy      = jsonencode(
            {
              + rules = [
                  + {
                      + action       = {
                          + type = "expire"
                        }
                      + description  = "Expire all untagged images"
                      + rulePriority = 1
                      + selection    = {
                          + countNumber = 1
                          + countType   = "imageCountMoreThan"
                          + tagStatus   = "untagged"
                        }
                    },
                  + {
                      + action       = {
                          + type = "expire"
                        }
                      + description  = "Expire the oldest image once we get 800 versions of that image"
                      + rulePriority = 2
                      + selection    = {
                          + countNumber = 800
                          + countType   = "imageCountMoreThan"
                          + tagStatus   = "any"
                        }
                    },
                ]
            }
        )
      + registry_id = (known after apply)
      + repository  = "bv-slate-docs"
    }

  # module.ecr.aws_ecr_repository.repository will be created
  + resource "aws_ecr_repository" "repository" {
      + arn                  = (known after apply)
      + id                   = (known after apply)
      + image_tag_mutability = "MUTABLE"
      + name                 = "bv-slate-docs"
      + registry_id          = (known after apply)
      + repository_url       = (known after apply)

      + image_scanning_configuration {
          + scan_on_push = true
        }
    }

  # module.ecr.aws_ecr_repository_policy.repo_jenkins_policy will be created
  + resource "aws_ecr_repository_policy" "repo_jenkins_policy" {
      + id          = (known after apply)
      + policy      = jsonencode(
            {
              + Statement = [
                  + {
                      + Action    = [
                          + "ecr:GetDownloadUrlForLayer",
                          + "ecr:BatchGetImage",
                          + "ecr:BatchCheckLayerAvailability",
                          + "ecr:PutImage",
                          + "ecr:InitiateLayerUpload",
                          + "ecr:UploadLayerPart",
                          + "ecr:CompleteLayerUpload",
                          + "ecr:DescribeRepositories",
                          + "ecr:GetRepositoryPolicy",
                          + "ecr:ListImages",
                          + "ecr:BatchDeleteImage",
                        ]
                      + Effect    = "Allow"
                      + Principal = {
                          + AWS = [
                              + "arn:aws:iam::596297932419:user/app_jenkins",
                            ]
                        }
                      + Sid       = "ECR Jenkins Policy"
                    },
                ]
              + Version   = "2008-10-17"
            }
        )
      + registry_id = (known after apply)
      + repository  = "bv-slate-docs"
    }

Plan: 3 to add, 0 to change, 0 to destroy.

------------------------------------------------------------------------

Note: You didn't specify an "-out" parameter to save this plan, so Terraform
can't guarantee that exactly these actions will be performed if
"terraform apply" is subsequently run.

apackard:bv-sandbox ashleypackard$ 
```